### PR TITLE
revert back to transition_post_status method

### DIFF
--- a/wp-discourse.php
+++ b/wp-discourse.php
@@ -130,7 +130,7 @@ class Discourse {
     
     add_action( 'save_post', array( $this, 'save_postdata' ) );
     add_action( 'xmlrpc_publish_post', array( $this, 'xmlrpc_publish_post_to_discourse' ) );
-    add_action( 'save_post', array( $this, 'publish_post_to_discourse' ), 10, 2 );
+    add_action( 'transition_post_status', array( $this, 'publish_post_to_discourse' ), 10, 2 );
   }
 
   public static function get_plugin_options() {
@@ -274,9 +274,11 @@ class Discourse {
     return $fields;
   }
 
-  function publish_post_to_discourse( $post_id, $post ) {
+  function publish_post_to_discourse( $new_status, $old_status, $post = NULL ) {
+    if ($post === NULL) return;
+
     $publish_to_discourse = get_post_meta( $post->ID, 'publish_to_discourse', true );
-    if ( ( self::publish_active() || ! empty( $publish_to_discourse ) ) && self::is_valid_sync_post_type( $post->ID ) ) {
+    if ( ( self::publish_active() || ! empty( $publish_to_discourse ) ) && $new_status == 'publish' && self::is_valid_sync_post_type( $post->ID ) ) {
       // This seems a little redundant after `save_postdata` but when using the Press This
       // widget it updates the field as it should.
 


### PR DESCRIPTION
`save_post` meant that discourse was getting posts that were scheduled for the future. Revert back to `transition_post_status` as the hook

the side effect is that we cannot direct publish anything as when this is called from a `"Publish"` action the primary category is yet to be set, meaning we don't have all the information necessary to publish to discourse.
